### PR TITLE
Adding Auth to function endpoints

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -377,7 +377,7 @@ exports.apiAuth = functions.https.onRequest(async (request, response) => {
   if (!key || !secret) {
     return response.status(401).send({error: "Unauthorized"})
   }
-  const usersRef = db.collection("users");
+  const usersRef = db.collection("apiUsers");
   const snapshot = await usersRef
     .where('apiKey', '==', key)
     .where('apiSecret', '==', secret)

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -8,6 +8,7 @@
         "@google-cloud/storage": "^5.8.1",
         "firebase-admin": "^9.5.0",
         "firebase-functions": "^3.13.2",
+        "jsonwebtoken": "^8.5.1",
         "sharp": "^0.27.2"
       },
       "devDependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
     "@google-cloud/storage": "^5.8.1",
     "firebase-admin": "^9.5.0",
     "firebase-functions": "^3.13.2",
+    "jsonwebtoken": "^8.5.1",
     "sharp": "^0.27.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Added JWT Auth to function endpoints
Users will need the following keys in order to use the API

- email (string)
- apiKey (string)
- apiSecret (string)
- apiAccess (boolean)

Need to set the firebase config value jwt.secret and never share this value. It's what is used to decrypt the token